### PR TITLE
Fix systemic classification initialization

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,6 +9,7 @@ sub_mod_assessment = {}
 pre_answers = {}
 answers = {}
 sys_risk_answers = {}
+systemic_classification = "N/A"
 
 # ---------------------------------------------
 # Title and Introduction


### PR DESCRIPTION
## Summary
- initialize `systemic_classification` before conditional logic
- add newline at end of file

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687bd8e829a0832186a2ee7409023126